### PR TITLE
 Prevent USB switching when PD is active

### DIFF
--- a/drivers/power/supply/qcom/smb5-lib.c
+++ b/drivers/power/supply/qcom/smb5-lib.c
@@ -7958,6 +7958,11 @@ static void set_usb_switch(struct smb_charger *chg, bool enable)
 		return;
 	}
 
+    if (chg->pd_active) {
+		pr_info("%s:pd_active return\n", __func__);
+		return;
+	}
+
 	if (enable) {
 		pr_debug("switch on fastchg\n");
 		chg->switch_on_fastchg = true;


### PR DESCRIPTION
This fix allows you to use the usb of a dock station, while the smartphone is charging. I talked about it on the Telegram group, but no one considered me. I solved it myself. Thx, Prevent USB switching when PD is active by @luk1337